### PR TITLE
Port to 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.0-SNAPSHOT'
+    id 'fabric-loom' version '1.3-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,11 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.2
-yarn_mappings=1.19.2+build.28
-loader_version=0.14.11
+minecraft_version=1.20.1
+#yarn_mappings=1.19.2+build.28
+loader_version=0.14.22
 # Mod Properties
-mod_version=0.1.0
+mod_version=0.2.0
 maven_group=supercoder79
 archives_base_name=structure-fixer
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "structure-fixer.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.10.0",
-    "minecraft": ">=1.19"
+    "fabricloader": ">=0.14.21",
+    "minecraft": ">=1.20"
   }
 }


### PR DESCRIPTION
Ported to 1.20.1 and made some slight tweaks. When updating a file, it now checks the file's DataVersion and compares it against the DataVersion for 1.20.1, only updating the file if the former value is less than the latter. This seems to have worked well for me, but feel free to revert.

Thanks for making this btw, was very useful!